### PR TITLE
Update template_contract_engels.tex

### DIFF
--- a/templates/template_contract_engels.tex
+++ b/templates/template_contract_engels.tex
@@ -50,7 +50,7 @@ printaddress,
 		{{productlist}}
 	\end{products}
 	
-	The amount due from {{company}} to GEWIS for this contract amounts to \euro{{{exclvat}} \euro{{{exclvat}} exluding VAT. The price specification is added as attachment. Payment by {{company}} will take place based on the invoices supplied by GEWIS, which will be send after every activity, if possible accompanied with evidence. Unless agreed upon otherwise, {{company}} will pay the invoice within 30 business days.
+	The amount due from {{company}} to GEWIS for this contract amounts to \euro{{{exclvat}}} excluding VAT. The price specification is added as attachment. Payment by {{company}} will take place based on the invoices supplied by GEWIS, which will be send after every activity, if possible accompanied with evidence. Unless agreed upon otherwise, {{company}} will pay the invoice within 30 business days.
 	\vspace{2em}
 	
 	\signature{{{firstcontractor}}\\{{firstcontractorfunction}}}


### PR DESCRIPTION
Changing spelling mistake exluding -> excluding and changing \euro as it was double and it did not include a closing bracket.