### PR TITLE
feat(database): allow enforcing of SSL for database connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ TYPEORM_SYNCHRONIZE = true
 TYPEORM_LOGGING = false
 TYPEORM_MIGRATIONS = dist/migration/**/*.js
 TYPEORM_SUBSCRIBERS = dist/subscriber/**/*.js
+TYPEORM_SSL_ENABLED = false
+TYPEORM_SSL_CACERTS = /etc/ssl/certs/ca-certificates.crt
 
 SESSION_SECRET = secret
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,5 @@
 import { DataSource } from 'typeorm';
+import fs from 'fs';
 import { Company } from './entity/Company';
 import { Contact } from './entity/Contact';
 import { Contract } from './entity/Contract';
@@ -32,6 +33,13 @@ const AppDataSource = new DataSource({
   type: process.env.TYPEORM_CONNECTION as 'postgres' | 'mariadb' | 'mysql',
   username: process.env.TYPEORM_USERNAME,
   password: process.env.TYPEORM_PASSWORD,
+  ...(process.env.TYPEORM_SSL_ENABLED === 'true' && process.env.TYPEORM_SSL_CACERTS
+    ? {
+        ssl: {
+          ca: fs.readFileSync(process.env.TYPEORM_SSL_CACERTS),
+        },
+      }
+    : {}),
   synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
   logging: process.env.TYPEORM_LOGGING === 'true',
   entities: [Company, Contact, Contract, IdentityApiKey, IdentityLDAP, IdentityLocal, Invoice, Product,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Several ways devised to implement this easily. Most logical is to enforce this feature only when actually running in production, but this does not work well when using CI for testing. So a `TYPEORM_SSL_ENABLED` environment variable provides more configuration flexibility (so you can also test this locally).

Originally, the path to the CA certificates file was hardcoded. However, this does not allow for flexibility on non-standard platforms that store it in a different location or specific requirements from the environment. As such, the `TYPEORM_SSL_CACERTS` has been introduced to handle that.

Based on https://github.com/GEWIS/sudosos-backend/pull/419.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_